### PR TITLE
add -t for tsv files

### DIFF
--- a/src/delimiter.rs
+++ b/src/delimiter.rs
@@ -14,7 +14,11 @@ pub enum Delimiter {
 
 impl Delimiter {
     /// Create a Delimiter by parsing the command line argument for the delimiter
-    pub fn from_arg(delimiter_arg: &Option<String>) -> Result<Self> {
+    pub fn from_arg(delimiter_arg: &Option<String>, tab_separation: bool) -> Result<Self> {
+        if tab_separation {
+            return Ok(Delimiter::Character('\t'.try_into()?));
+        }
+
         if let Some(s) = delimiter_arg {
             if s == "auto" {
                 return Ok(Delimiter::Auto);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod ui;
 mod util;
 mod view;
 mod wrap;
+
 use crate::app::App;
 use crate::delimiter::Delimiter;
 
@@ -98,6 +99,10 @@ struct Args {
     #[clap(short, long)]
     delimiter: Option<String>,
 
+    /// Use tab separation. Shortcut for -d '<TAB>'.
+    #[clap(short = 't', long)]
+    tab_separated: bool,
+
     /// Searches ignore case. Ignored if any uppercase letters are present in the search string
     #[clap(short, long)]
     ignore_case: bool,
@@ -158,7 +163,7 @@ fn run_csvlens() -> Result<Option<String>> {
     let args = Args::parse();
 
     let show_stats = args.debug;
-    let delimiter = Delimiter::from_arg(&args.delimiter)?;
+    let delimiter = Delimiter::from_arg(&args.delimiter, args.tab_separated)?;
 
     let file = SeekableFile::new(&args.filename)?;
     let filename = file.filename();


### PR DESCRIPTION
As the title says, this PR adds a  new command line flag -t or --tab-separated for tsv files which is a shortcut for `-d <TAB` since TAB is kinda hard to write in the cli.