### PR TITLE
Accept slash-t for tab as delimiter argument

### DIFF
--- a/src/delimiter.rs
+++ b/src/delimiter.rs
@@ -19,6 +19,9 @@ impl Delimiter {
             if s == "auto" {
                 return Ok(Delimiter::Auto);
             }
+            if s == r"\t" {
+                return Ok(Delimiter::Character(b'\t'));
+            }
             let mut chars = s.chars();
             let c = chars.next().context("Delimiter should not be empty")?;
             if !c.is_ascii() {
@@ -28,7 +31,7 @@ impl Delimiter {
                 );
             }
             if chars.next().is_some() {
-                bail!("Delimiter should be exactly one character, got {}", s);
+                bail!("Delimiter should be exactly one character (or \\t), got '{}'", s);
             }
             Ok(Delimiter::Character(c.try_into()?))
         } else {

--- a/src/delimiter.rs
+++ b/src/delimiter.rs
@@ -31,7 +31,10 @@ impl Delimiter {
                 );
             }
             if chars.next().is_some() {
-                bail!("Delimiter should be exactly one character (or \\t), got '{}'", s);
+                bail!(
+                    "Delimiter should be exactly one character (or \\t), got '{}'",
+                    s
+                );
             }
             Ok(Delimiter::Character(c.try_into()?))
         } else {


### PR DESCRIPTION
Cross reference #19, currently to use a tab you must use:

```
$ csvlens -d $'\t' ...
```

With this change the following are also accepted:

```
$ csvlens -d '\t' ...
$ csvlens -d "\t" ...
```

This convention is used elsewhere, including the ``xsv`` and ``qsv`` tools:

https://github.com/BurntSushi/xsv/blob/0.13.0/src/config.rs#L37

https://github.com/jqnatividad/qsv/blob/0.121.0/src/config.rs#L47