### PR TITLE
add installation instructions for Windows using winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ cargo install --path $(pwd)
 ```
 pkgin install csvlens
 ```
+
+### Windows
+
+For Windows, `csvlens` is available on [winget](https://learn.microsoft.com/en-gb/windows/package-manager/).
+You can install it using:
+```powershell
+winget install --id YS-L.csvlens
+```


### PR DESCRIPTION
I created a [winget package](https://github.com/microsoft/winget-pkgs/pull/133930) (and also an update for the new [0.6.0](https://github.com/microsoft/winget-pkgs/pull/134408)) release so that installation on Windows can be automated.

If you are interested in automating this or maintaining this yourself, have a look at [komac](https://github.com/russellbanks/Komac) and the GitHub Actions integration mentioned in the readme.