### PR TITLE
Fix shift related key bindings not working in Windows

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -73,7 +73,16 @@ impl InputHandler {
     }
 
     pub fn next(&mut self) -> Control {
-        if let CsvlensEvent::Input(key) = self.events.next().unwrap() {
+        if let CsvlensEvent::Input(mut key) = self.events.next().unwrap() {
+            let platform_consistent_shift = match (key.code, key.modifiers) {
+                (KeyCode::Char(c), _) => c.is_ascii_uppercase(),
+                (_, m) => m.contains(KeyModifiers::SHIFT),
+            };
+            if platform_consistent_shift {
+                key.modifiers.insert(KeyModifiers::SHIFT);
+            } else {
+                key.modifiers.remove(KeyModifiers::SHIFT);
+            }
             if self.is_help_mode() {
                 return self.handler_help(key);
             } else if self.is_input_buffering() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -74,6 +74,25 @@ impl InputHandler {
 
     pub fn next(&mut self) -> Control {
         if let CsvlensEvent::Input(mut key) = self.events.next().unwrap() {
+            /*
+            The shift key modifier is not consistent across platforms.
+
+            For upper case alphabets, e.g. 'A'
+
+            Unix: Char("A") + SHIFT
+            Windows: Char("A") + SHIFT
+
+            For non-alphabets, e.g. '>'
+
+            Unix: Char(">") + NULL
+            Windows: Char(">") + SHIFT
+
+            But the key event handling below assumes that the shift key modifier is only added for
+            alphabets. To satisfy the assumption, the following ensures that the presence or absence
+            of shift modifier is consistent across platforms.
+
+            Idea borrowed from: https://github.com/sxyazi/yazi/pull/174
+            */
             let platform_consistent_shift = match (key.code, key.modifiers) {
                 (KeyCode::Char(c), _) => c.is_ascii_uppercase(),
                 (_, m) => m.contains(KeyModifiers::SHIFT),


### PR DESCRIPTION
Fixes #82.