### PR TITLE
Feat: Add Bidi unic support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tui-input",
+ "unic-bidi",
 ]
 
 [[package]]
@@ -1013,6 +1014,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1578,6 +1585,57 @@ checksum = "b3e785f863a3af4c800a2a669d0b64c879b538738e352607e2624d03f868dc01"
 dependencies = [
  "crossterm",
  "unicode-width",
+]
+
+[[package]]
+name = "unic-bidi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1356b759fb6a82050666f11dce4b6fe3571781f1449f3ef78074e408d468ec09"
+dependencies = [
+ "matches",
+ "unic-ucd-bidi",
+]
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-ucd-bidi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d568b51222484e1f8209ce48caa6b430bf352962b877d592c29ab31fb53d8c"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ arrow = {version = "50.0.0", default-features = false, features = ["csv"]}
 sorted-vec = "0.8.3"
 arboard = { version = "3.3.2", features = ["wayland-data-control"], optional = true }
 thiserror = "1.0.63"
+unic-bidi = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
 crossterm = "0.27.0"

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -9,6 +9,8 @@ use std::time;
 
 use crate::errors::CsvlensResult;
 
+use unic_bidi::BidiInfo;
+
 fn string_record_to_vec(record: &csv::StringRecord) -> Vec<String> {
     let mut string_vec = Vec::new();
     for field in record.iter() {
@@ -239,7 +241,15 @@ impl CsvLensReader {
                         let string_record = r?;
                         let mut fields = Vec::new();
                         for field in string_record.iter() {
-                            fields.push(String::from(field));
+                            if field.is_empty() {
+                                fields.push(String::from(""));
+                                continue;
+                            }
+                            let bidi_info = BidiInfo::new(field, None);
+                            let para = &bidi_info.paragraphs[0];
+                            let line = para.range.clone();
+                            let display = bidi_info.reorder_line(para, line);
+                            fields.push(String::from(display));
                         }
                         let row = Row {
                             record_num: self.config.position_to_record_num(record_position)


### PR DESCRIPTION
Using the [unic_bidi](https://docs.rs/unic-bidi/latest/unic_bidi/) Crate to add bidirectional unicode support. 

Before:
![image](https://github.com/user-attachments/assets/1c8f4759-5052-406b-8ce4-f3cdb073be00)

After:
![image](https://github.com/user-attachments/assets/0b8af4eb-8876-4fd1-a3ce-2521aa6fae91)
