### PR TITLE
Track rendering time in debug stats

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -241,6 +241,7 @@ impl App {
         }
 
         app.rows_view.set_sort_order(app.sort_order)?;
+        app.csv_table_state.debug_stats.show_stats(app.show_stats);
 
         Ok(app)
     }
@@ -597,17 +598,15 @@ impl App {
         }
 
         // update rows and elapsed time if there are new results
-        if self.show_stats {
+        self.csv_table_state
+            .debug_stats
+            .rows_view_perf(self.rows_view.perf_stats());
+        if let Some(fdr) = &self.finder {
             self.csv_table_state
                 .debug_stats
-                .rows_view_perf(self.rows_view.perf_stats());
-            if let Some(fdr) = &self.finder {
-                self.csv_table_state
-                    .debug_stats
-                    .finder_elapsed(fdr.elapsed());
-            } else {
-                self.csv_table_state.debug_stats.finder_elapsed(None);
-            }
+                .finder_elapsed(fdr.elapsed());
+        } else {
+            self.csv_table_state.debug_stats.finder_elapsed(None);
         }
 
         // TODO: is this update too late?
@@ -830,11 +829,9 @@ impl App {
         terminal.draw(|f| {
             self.render_frame(f);
         })?;
-        if self.show_stats {
-            self.csv_table_state
-                .debug_stats
-                .render_elapsed(Some(start.elapsed()));
-        }
+        self.csv_table_state
+            .debug_stats
+            .render_elapsed(Some(start.elapsed()));
         Ok(())
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -833,7 +833,7 @@ impl App {
         if self.show_stats {
             self.csv_table_state
                 .debug_stats
-                .render_elapsed(Some(start.elapsed().as_micros()));
+                .render_elapsed(Some(start.elapsed()));
         }
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use regex::Regex;
 use std::cmp::min;
 use std::sync::Arc;
+use std::time::Instant;
 
 fn get_offsets_to_make_visible(
     found_record: &find::FoundRecord,
@@ -825,10 +826,15 @@ impl App {
     }
 
     fn draw<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> CsvlensResult<()> {
+        let start = Instant::now();
         terminal.draw(|f| {
             self.render_frame(f);
         })?;
-
+        if self.show_stats {
+            self.csv_table_state
+                .debug_stats
+                .render_elapsed(Some(start.elapsed().as_micros()));
+        }
         Ok(())
     }
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -7,7 +7,7 @@ use sorted_vec::SortedVec;
 use std::cmp::min;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::{self};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub struct Finder {
     internal: Arc<Mutex<FinderInternalState>>,
@@ -183,7 +183,7 @@ impl Finder {
         m_guard.terminate();
     }
 
-    pub fn elapsed(&self) -> Option<u128> {
+    pub fn elapsed(&self) -> Option<Duration> {
         let m_guard = self.internal.lock().unwrap();
         m_guard.elapsed()
     }
@@ -223,7 +223,7 @@ struct FinderInternalState {
     founds: SortedVec<FoundRecord>,
     done: bool,
     should_terminate: bool,
-    elapsed: Option<u128>,
+    elapsed: Option<Duration>,
 }
 
 impl FinderInternalState {
@@ -294,7 +294,7 @@ impl FinderInternalState {
 
             let mut m = _m.lock().unwrap();
             m.done = true;
-            m.elapsed = Some(start.elapsed().as_micros());
+            m.elapsed = Some(start.elapsed());
         });
 
         m_state
@@ -326,7 +326,7 @@ impl FinderInternalState {
         self.should_terminate = true;
     }
 
-    fn elapsed(&self) -> Option<u128> {
+    fn elapsed(&self) -> Option<Duration> {
         self.elapsed
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1053,6 +1053,7 @@ struct BordersState {
 }
 
 pub struct DebugStats {
+    show_stats: bool,
     rows_view_stats: Option<crate::view::PerfStats>,
     finder_elapsed: Option<Duration>,
     render_elapsed: Option<Duration>,
@@ -1061,10 +1062,15 @@ pub struct DebugStats {
 impl DebugStats {
     pub fn new() -> Self {
         DebugStats {
+            show_stats: false,
             rows_view_stats: None,
             finder_elapsed: None,
             render_elapsed: None,
         }
+    }
+
+    pub fn show_stats(&mut self, show: bool) {
+        self.show_stats = show;
     }
 
     pub fn rows_view_perf(&mut self, stats: Option<crate::view::PerfStats>) {
@@ -1080,6 +1086,9 @@ impl DebugStats {
     }
 
     pub fn status_line(&self) -> Option<String> {
+        if !self.show_stats {
+            return None;
+        }
         let mut line = "[".to_string();
         if let Some(stats) = &self.rows_view_stats {
             line += format!(
@@ -1104,11 +1113,7 @@ impl DebugStats {
             line += format!(" render:{:.3}ms", elapsed.as_micros() as f64 / 1000.0).as_str();
         }
         line += "]";
-        if line == "[]" {
-            None
-        } else {
-            Some(line)
-        }
+        Some(line)
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,6 +20,7 @@ use tui_input::Input;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 const NUM_SPACES_AFTER_LINE_NUMBER: u16 = 2;
 const NUM_SPACES_BETWEEN_COLUMNS: u16 = 4;
@@ -1053,8 +1054,8 @@ struct BordersState {
 
 pub struct DebugStats {
     rows_view_stats: Option<crate::view::PerfStats>,
-    finder_elapsed: Option<f64>,
-    render_elapsed: Option<f64>,
+    finder_elapsed: Option<Duration>,
+    render_elapsed: Option<Duration>,
 }
 
 impl DebugStats {
@@ -1070,12 +1071,12 @@ impl DebugStats {
         self.rows_view_stats = stats;
     }
 
-    pub fn finder_elapsed(&mut self, elapsed: Option<u128>) {
-        self.finder_elapsed = elapsed.map(|e| e as f64 / 1000.0);
+    pub fn finder_elapsed(&mut self, elapsed: Option<Duration>) {
+        self.finder_elapsed = elapsed;
     }
 
-    pub fn render_elapsed(&mut self, elapsed: Option<u128>) {
-        self.render_elapsed = elapsed.map(|e| e as f64 / 1000.0);
+    pub fn render_elapsed(&mut self, elapsed: Option<Duration>) {
+        self.render_elapsed = elapsed;
     }
 
     pub fn status_line(&self) -> Option<String> {
@@ -1097,10 +1098,10 @@ impl DebugStats {
             .as_str();
         }
         if let Some(elapsed) = self.finder_elapsed {
-            line += format!(" finder:{elapsed}ms").as_str();
+            line += format!(" finder:{:.3}ms", elapsed.as_micros() as f64 / 1000.0).as_str();
         }
         if let Some(elapsed) = self.render_elapsed {
-            line += format!(" render:{elapsed}ms").as_str();
+            line += format!(" render:{:.3}ms", elapsed.as_micros() as f64 / 1000.0).as_str();
         }
         line += "]";
         if line == "[]" {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1054,6 +1054,7 @@ struct BordersState {
 pub struct DebugStats {
     rows_view_stats: Option<crate::view::PerfStats>,
     finder_elapsed: Option<f64>,
+    render_elapsed: Option<f64>,
 }
 
 impl DebugStats {
@@ -1061,6 +1062,7 @@ impl DebugStats {
         DebugStats {
             rows_view_stats: None,
             finder_elapsed: None,
+            render_elapsed: None,
         }
     }
 
@@ -1070,6 +1072,10 @@ impl DebugStats {
 
     pub fn finder_elapsed(&mut self, elapsed: Option<u128>) {
         self.finder_elapsed = elapsed.map(|e| e as f64 / 1000.0);
+    }
+
+    pub fn render_elapsed(&mut self, elapsed: Option<u128>) {
+        self.render_elapsed = elapsed.map(|e| e as f64 / 1000.0);
     }
 
     pub fn status_line(&self) -> Option<String> {
@@ -1092,6 +1098,9 @@ impl DebugStats {
         }
         if let Some(elapsed) = self.finder_elapsed {
             line += format!(" finder:{elapsed}ms").as_str();
+        }
+        if let Some(elapsed) = self.render_elapsed {
+            line += format!(" render:{elapsed}ms").as_str();
         }
         line += "]";
         if line == "[]" {


### PR DESCRIPTION
Track rendering time in debut stats to be displayed when using the `--debug` flag.