### PR TITLE
Use line buffered stderr to improve rendering performance

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,6 +11,7 @@ use crossterm::terminal::{
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::ffi::OsString;
+use std::io::LineWriter;
 use std::panic;
 use std::thread::panicking;
 
@@ -81,7 +82,7 @@ impl AppRunner {
         let mut output = std::io::stderr();
         execute!(output, EnterAlternateScreen)?;
 
-        let backend = CrosstermBackend::new(output);
+        let backend = CrosstermBackend::new(LineWriter::new(output));
         let mut terminal = Terminal::new(backend)?;
 
         self.app.main_loop(&mut terminal)


### PR DESCRIPTION
Since stderr is unbuffered by default and csvlens uses it for output, switching to buffered output significantly improves rendering performance - up to 10x in some cases - especially when most of the screen needs to be re-rendered.

Before:

![image](https://github.com/user-attachments/assets/26b86699-81eb-456d-abf3-ddd0756f0ed9)

After: 

![image](https://github.com/user-attachments/assets/1f5bbc34-115d-4b34-ae2c-24a84cc61d29)