### PR TITLE
feat: make freeze columns option available when using csvlens as a library

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -173,6 +173,7 @@ impl App {
         columns_regex: Option<String>,
         filter_regex: Option<String>,
         find_regex: Option<String>,
+        freeze_cols_offset: Option<u64>,
     ) -> CsvlensResult<Self> {
         let input_handler = InputHandler::new();
 
@@ -192,7 +193,12 @@ impl App {
         let shared_config = Arc::new(config);
 
         let csvlens_reader = csv::CsvLensReader::new(shared_config.clone())?;
-        let rows_view = view::RowsView::new(csvlens_reader, num_rows as u64)?;
+        let mut rows_view = view::RowsView::new(csvlens_reader, num_rows as u64)?;
+
+        // Set the number of columns to freeze
+        if let Some(freeze_cols_offset) = freeze_cols_offset {
+            rows_view.set_cols_offset_num_freeze(freeze_cols_offset);
+        }
 
         if let Some(column_name) = &echo_column {
             if !rows_view.headers().iter().any(|h| h.name == *column_name) {
@@ -922,6 +928,7 @@ mod tests {
                 self.columns_regex,
                 self.filter_regex,
                 self.find_regex,
+                None,
             )
         }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -74,6 +74,7 @@ impl From<Args> for CsvlensOptions {
             ignore_case: args.ignore_case,
             echo_column: args.echo_column,
             debug: args.debug,
+            freeze_cols_offset: None,
         }
     }
 }
@@ -91,6 +92,7 @@ pub struct CsvlensOptions {
     pub ignore_case: bool,
     pub echo_column: Option<String>,
     pub debug: bool,
+    pub freeze_cols_offset: Option<u64>,
 }
 
 struct AppRunner {
@@ -174,6 +176,7 @@ pub fn run_csvlens_with_options(options: CsvlensOptions) -> CsvlensResult<Option
         options.columns,
         options.filter,
         options.find,
+        options.freeze_cols_offset,
     )?;
 
     let mut app_runner = AppRunner::new(app);


### PR DESCRIPTION
Thanks @YS-L for adding the Freeze Columns option in the UI.

I made a small change to the library so I can take advantage of it programatically.