### PR TITLE
Make `--colorful` default

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -183,7 +183,7 @@ impl App {
         filter_regex: Option<String>,
         find_regex: Option<String>,
         freeze_cols_offset: Option<u64>,
-        color_columns: bool,
+        no_color_columns: bool,
         prompt: Option<String>,
         wrap_mode: Option<WrapMode>,
     ) -> CsvlensResult<Self> {
@@ -223,7 +223,7 @@ impl App {
             rows_view.headers().len(),
             &echo_column,
             ignore_case,
-            color_columns,
+            no_color_columns,
             prompt,
         );
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -82,8 +82,8 @@ struct Args {
     echo_column: Option<String>,
 
     /// Whether to display each column in a different color
-    #[arg(long, alias = "colorful", visible_alias = "colorful")]
-    color_columns: bool,
+    #[arg(long, alias = "no-color", visible_alias = "no-color")]
+    no_color_columns: bool,
 
     /// Show a custom prompt message in the status bar. Supports ANSI escape codes for colored or
     /// styled text.
@@ -146,7 +146,7 @@ impl From<Args> for CsvlensOptions {
             echo_column: args.echo_column,
             debug: args.debug,
             freeze_cols_offset: None,
-            color_columns: args.color_columns,
+            no_color_columns: args.no_color_columns,
             prompt: args.prompt,
             wrap_mode: Args::get_wrap_mode(args.wrap, args.wrap_chars, args.wrap_words),
         }
@@ -167,7 +167,7 @@ pub struct CsvlensOptions {
     pub echo_column: Option<String>,
     pub debug: bool,
     pub freeze_cols_offset: Option<u64>,
-    pub color_columns: bool,
+    pub no_color_columns: bool,
     pub prompt: Option<String>,
     pub wrap_mode: Option<WrapMode>,
 }
@@ -254,7 +254,7 @@ pub fn run_csvlens_with_options(options: CsvlensOptions) -> CsvlensResult<Option
         options.filter,
         options.find,
         options.freeze_cols_offset,
-        options.color_columns,
+        options.no_color_columns,
         options.prompt,
         options.wrap_mode,
     )?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -443,7 +443,7 @@ impl<'a> CsvTable<'a> {
             }
             let effective_width = min(remaining_width, hlen);
             let mut content_style = Style::default();
-            if state.color_columns {
+            if !state.no_color_columns {
                 content_style = content_style
                     .fg(state.theme.column_colors[col_index % state.theme.column_colors.len()]);
             }
@@ -1260,7 +1260,7 @@ pub struct CsvTableState {
     pub column_width_overrides: ColumnWidthOverrides,
     pub cursor_xy: Option<(u16, u16)>,
     pub theme: Theme,
-    pub color_columns: bool,
+    pub no_color_columns: bool,
     pub prompt: Option<String>,
     pub debug: String,
 }
@@ -1271,7 +1271,7 @@ impl CsvTableState {
         total_cols: usize,
         echo_column: &Option<String>,
         ignore_case: bool,
-        color_columns: bool,
+        no_color_columns: bool,
         prompt: Option<String>,
     ) -> Self {
         Self {
@@ -1299,7 +1299,7 @@ impl CsvTableState {
             column_width_overrides: ColumnWidthOverrides::new(),
             cursor_xy: None,
             theme: Theme::default(),
-            color_columns,
+            no_color_columns,
             prompt,
             debug: "".into(),
         }


### PR DESCRIPTION
Resolve #141

Make `--colorful` by default, introduce `--no-color`.

I think it's generally better to color by default, allowing explicit disable by `--no-color`.

Two concerns.
1. Leave or drop `--colorful` arg. Should I leave it for backward compatibility?
2. Naming `--no-color`. I think `--no-color` is great, but `--nocolor`, `--monochrome`, or any other is fine.
