### PR TITLE
Skip test_copy_selection_crlf on CI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2643,6 +2643,11 @@ mod tests {
 
     #[test]
     fn test_copy_selection_crlf() {
+        // Skip test in CI environments where clipboard is not available
+        if std::env::var("CI").is_ok() {
+            return;
+        }
+
         let mut app = AppBuilder::new("tests/data/cell_with_crlf.csv")
             .build()
             .unwrap();


### PR DESCRIPTION
Skip `test_copy_selection_crlf` on CI since clipboard operations are not available.