### PR TITLE
Issue #180 column number fix

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1340,7 +1340,7 @@ mod tests {
             "4  │  71      48      0       Worcester          │                              ",
             "5  │  89      46      11      Wisconsin Dells    │                              ",
             "───┴─────────────────────────────────────────────┴──────────────────────────────",
-            "stdin [Row 1/128, Col 5/10] [Filter \"Lon|City\": 4/10 cols]                      ",
+            "stdin [Row 1/128, Col 5/10] [Filter \"Lon|City\": 1/4 cols]                       ",
         ];
         let actual_buffer = terminal.backend().buffer().clone();
         let lines = to_lines(&actual_buffer);
@@ -1370,7 +1370,7 @@ mod tests {
             "   │           │                                                                ",
             "   │           │                                                                ",
             "───┴───────────┴────────────────────────────────────────────────────────────────",
-            "stdin [Row 1/2, Col 2/2] [Filter \"COL2\": 1/2 cols]                              ",
+            "stdin [Row 1/2, Col 2/2] [Filter \"COL2\": 1/1 cols]                              ",
         ];
         let actual_buffer = terminal.backend().buffer().clone();
         let lines = to_lines(&actual_buffer);
@@ -1433,7 +1433,7 @@ mod tests {
             "4  │  Worcester          MA       │                                             ",
             "5  │  Wisconsin Dells    WI       │                                             ",
             "───┴──────────────────────────────┴─────────────────────────────────────────────",
-            "stdin [Row 1/128, Col 9/10] [Filter \"(?i)city|state|wa\": 2/10 cols] [ignore-case",
+            "stdin [Row 1/128, Col 9/10] [Filter \"(?i)city|state|wa\": 1/2 cols] [ignore-case]",
         ];
         let actual_buffer = terminal.backend().buffer().clone();
         let lines = to_lines(&actual_buffer);
@@ -2022,7 +2022,7 @@ mod tests {
             "    │                    │                                                                                              ",
             "    │                    │                                                                                              ",
             "────┴────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────",
-            "stdin [Row 97/128, Col 9/10] [Filter \"Salt Lake City\": 1/1] [Filter \"City\": 1/10 cols]                                  ",
+            "stdin [Row 97/128, Col 9/10] [Filter \"Salt Lake City\": 1/1] [Filter \"City\": 1/1 cols]                                   ",
         ];
         let actual_buffer = terminal.backend().buffer().clone();
         let lines = to_lines(&actual_buffer);
@@ -2187,7 +2187,7 @@ mod tests {
             "4  │  42      …   12              │                                             ",
             "5  │  43      …   48              │                                             ",
             "───┴──────────────────────────────┴─────────────────────────────────────────────",
-            "stdin [Row 1/128, Col 2/10] [Filter \"Lat\": 3/10 cols]                           ",
+            "stdin [Row 1/128, Col 2/10] [Filter \"Lat\": 2/3 cols]                            ",
         ];
         assert_eq!(lines, expected);
 
@@ -2413,7 +2413,7 @@ mod tests {
             "93  │  32      42      35      San Diego         │                              ",
             "91  │  37      46      47      San Francisco     │                              ",
             "────┴────────────────────────────────────────────┴──────────────────────────────",
-            "stdin [Row 96/128, Col 1/10] [Filter \"San\": 1/11] [Filter \"Lat|City\": 4/10 cols]",
+            "stdin [Row 96/128, Col 1/10] [Filter \"San\": 1/11] [Filter \"Lat|City\": 1/4 cols] ",
         ];
         assert_eq!(lines, expected);
 
@@ -2434,7 +2434,7 @@ mod tests {
             "89  │  33      45      35      Santa Ana        │                               ",
             "92  │  41      27      0       Sandusky         │                               ",
             "────┴───────────────────────────────────────────┴───────────────────────────────",
-            "stdin [Row 86/128, Col 9/10] [Filter \"San\": -/11] [Filter \"Lat|City\": 4/10 cols]",
+            "stdin [Row 86/128, Col 9/10] [Filter \"San\": -/11] [Filter \"Lat|City\": 4/4 cols] ",
         ];
         assert_eq!(lines, expected);
     }
@@ -2494,7 +2494,7 @@ mod tests {
             "4  │  42      16      12      │                                                 ",
             "5  │  43      37      48      │                                                 ",
             "───┴──────────────────────────┴─────────────────────────────────────────────────",
-            "stdin [Row 1/128, Col 1/10] [Filter \"Lat\": 3/10 cols]                           ",
+            "stdin [Row 1/128, Col 1/10] [Filter \"Lat\": 1/3 cols]                            ",
         ];
         let actual_buffer = terminal.backend().buffer().clone();
         let lines = to_lines(&actual_buffer);

--- a/src/columns_filter.rs
+++ b/src/columns_filter.rs
@@ -6,7 +6,6 @@ pub struct ColumnsFilter {
     indices: Vec<usize>,
     filtered_headers: Vec<String>,
     filtered_flags: Vec<bool>,
-    num_columns_before_filter: usize,
     disabled_because_no_match: bool,
 }
 
@@ -37,7 +36,6 @@ impl ColumnsFilter {
             indices,
             filtered_headers,
             filtered_flags,
-            num_columns_before_filter: headers.len(),
             disabled_because_no_match,
         }
     }
@@ -56,10 +54,6 @@ impl ColumnsFilter {
 
     pub fn num_filtered(&self) -> usize {
         self.indices.len()
-    }
-
-    pub fn num_original(&self) -> usize {
-        self.num_columns_before_filter
     }
 
     pub fn disabled_because_no_match(&self) -> bool {


### PR DESCRIPTION
Hello @YS-L,

This PR tries to fix the problem described in #180.
Please let me know if this is the right fix for this problem.

Kind regards,

**Previous behavior**: the status bar “Col” value always showed the scroll offset (first visible non-frozen column as 1). In column mode this often lagged or restarted on viewport scrolls, and didn’t reflect the selected column. In wrapped/filtered views it stayed offset-based.

**New behavior**: the status bar shows the actual selected column number when in cell mode (row + column), with line wrap off and no active filter; otherwise it keeps the offset-based display for consistency in row/column-only modes, wrapped views, and filters. This makes column numbers update correctly during navigation while preserving expected wrapped/filter behavior.