### PR TITLE
feat: add number formatting options for display (#197)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -183,6 +183,7 @@ pub struct App {
     sorter: Option<Arc<sort::Sorter>>,
     sort_order: SortOrder,
     wrap_mode: WrapMode,
+    column_format_config: Option<Arc<crate::format::ColumnFormatConfig>>,
     #[cfg(feature = "clipboard")]
     clipboard: Result<Clipboard>,
     _seekable_file: SeekableFile,
@@ -206,6 +207,7 @@ impl App {
         wrap_mode: Option<WrapMode>,
         auto_reload: bool,
         no_streaming_stdin: bool,
+        column_format_config: Option<crate::format::ColumnFormatConfig>,
     ) -> CsvlensResult<Self> {
         // TODO: pass a base_config to wait for header properly?
         let seekable_file = SeekableFile::new(&original_filename, no_streaming_stdin)?;
@@ -270,6 +272,15 @@ impl App {
             Err(e) => Err(anyhow::anyhow!(e)),
         };
 
+        // Warn if --column-format is used with --no-headers: named column formats will never match.
+        if no_headers {
+            if let Some(ref cfg) = column_format_config {
+                if cfg.has_named() {
+                    eprintln!("Warning: --column-format has no effect when --no-headers is used (columns have no names)");
+                }
+            }
+        }
+
         let mut app = App {
             input_handler,
             num_rows_not_visible,
@@ -288,6 +299,7 @@ impl App {
             sorter: None,
             sort_order: SortOrder::Ascending,
             wrap_mode: WrapMode::default(),
+            column_format_config: column_format_config.map(Arc::new),
             #[cfg(feature = "clipboard")]
             clipboard,
             _seekable_file: seekable_file,
@@ -1093,6 +1105,7 @@ impl App {
 
         let rows = self.rows_view.rows();
         let csv_table = CsvTable::new(self.rows_view.headers(), rows);
+        self.csv_table_state.column_format_config = self.column_format_config.clone();
         f.render_stateful_widget(csv_table, size, &mut self.csv_table_state);
         if let Some((x, y)) = self.csv_table_state.cursor_xy {
             f.set_cursor_position(Position::new(x, y));
@@ -1131,6 +1144,7 @@ mod tests {
         find_regex: Option<String>,
         prompt: Option<String>,
         wrap_mode: Option<WrapMode>,
+        column_format_config: Option<crate::format::ColumnFormatConfig>,
     }
 
     impl AppBuilder {
@@ -1147,6 +1161,7 @@ mod tests {
                 find_regex: None,
                 prompt: Some("stdin".to_owned()),
                 wrap_mode: None,
+                column_format_config: None,
             }
         }
 
@@ -1167,6 +1182,7 @@ mod tests {
                 self.wrap_mode,
                 false,
                 false,
+                self.column_format_config,
             )
         }
 
@@ -1212,6 +1228,11 @@ mod tests {
 
         fn wrap_mode(mut self, wrap_mode: Option<WrapMode>) -> Self {
             self.wrap_mode = wrap_mode;
+            self
+        }
+
+        pub fn column_format_config(mut self, config: crate::format::ColumnFormatConfig) -> Self {
+            self.column_format_config = Some(config);
             self
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,479 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum NumberFormat {
+    Thousands,  // e.g. 1,234,567.89
+    Scientific, // e.g. 1.23e6
+    Si,         // e.g. 1.23M  (k/M/B/T)
+    Fixed,      // e.g. 23.51  (decimal places controlled by --precision)
+}
+
+impl NumberFormat {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "thousands" => Some(NumberFormat::Thousands),
+            "scientific" | "sci" => Some(NumberFormat::Scientific),
+            "si" => Some(NumberFormat::Si),
+            "fixed" => Some(NumberFormat::Fixed),
+            _ => None,
+        }
+    }
+
+    /// Formats `value` according to this number format.
+    /// `precision` controls decimal places for Scientific/Si/Fixed; defaults to 2 if None.
+    /// For Thousands, `precision` truncates/pads decimal places if specified;
+    /// if None, the original decimal representation is preserved.
+    /// Returns the original string unchanged if `value` cannot be parsed as a finite number.
+    pub fn apply(&self, value: &str, precision: Option<usize>) -> String {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return value.to_string();
+        }
+        let f: f64 = match trimmed.parse() {
+            Ok(v) => v,
+            Err(_) => return value.to_string(),
+        };
+        if f.is_nan() || f.is_infinite() {
+            return value.to_string();
+        }
+        match self {
+            NumberFormat::Thousands => format_thousands(f, precision),
+            NumberFormat::Scientific => format_scientific(f, precision.unwrap_or(2)),
+            NumberFormat::Si => format_human(f, precision.unwrap_or(2)),
+            NumberFormat::Fixed => format_fixed(f, precision.unwrap_or(2)),
+        }
+    }
+}
+
+fn format_thousands(f: f64, precision: Option<usize>) -> String {
+    let negative = f < 0.0;
+    // Use precision-controlled formatting if specified, otherwise preserve original representation.
+    let abs_str = match precision {
+        Some(p) => format!("{:.prec$}", f.abs(), prec = p),
+        None => format!("{}", f.abs()),
+    };
+
+    // Split on '.'
+    let (int_part, dec_part) = if let Some(dot_pos) = abs_str.find('.') {
+        (&abs_str[..dot_pos], Some(&abs_str[dot_pos..]))
+    } else {
+        (abs_str.as_str(), None)
+    };
+
+    // Insert commas every 3 digits from the right
+    let int_chars: Vec<char> = int_part.chars().collect();
+    let mut with_commas = String::new();
+    let len = int_chars.len();
+    for (i, ch) in int_chars.iter().enumerate() {
+        if i > 0 && (len - i) % 3 == 0 {
+            with_commas.push(',');
+        }
+        with_commas.push(*ch);
+    }
+
+    let result = match dec_part {
+        Some(dec) => format!("{}{}", with_commas, dec),
+        None => with_commas,
+    };
+
+    if negative {
+        format!("-{}", result)
+    } else {
+        result
+    }
+}
+
+fn format_scientific(f: f64, precision: usize) -> String {
+    // Special-case zero: log10(0) is undefined (-∞), handle separately.
+    if f == 0.0 {
+        return format!("{:.prec$}e0", 0.0, prec = precision);
+    }
+    let negative = f < 0.0;
+    let abs_f = f.abs();
+    let exp = abs_f.log10().floor() as i32;
+    let mantissa = abs_f / 10f64.powi(exp);
+    let result = format!("{:.prec$}e{}", mantissa, exp, prec = precision);
+    if negative {
+        format!("-{}", result)
+    } else {
+        result
+    }
+}
+
+fn format_fixed(f: f64, precision: usize) -> String {
+    format!("{:.prec$}", f, prec = precision)
+}
+
+fn format_human(f: f64, precision: usize) -> String {
+    let negative = f < 0.0;
+    let abs_f = f.abs();
+
+    let result = if abs_f >= 1e12 {
+        format!("{:.prec$}T", abs_f / 1e12, prec = precision)
+    } else if abs_f >= 1e9 {
+        format!("{:.prec$}B", abs_f / 1e9, prec = precision)
+    } else if abs_f >= 1e6 {
+        format!("{:.prec$}M", abs_f / 1e6, prec = precision)
+    } else if abs_f >= 1e3 {
+        format!("{:.prec$}k", abs_f / 1e3, prec = precision)
+    } else {
+        // Below 1000: no suffix, still apply precision.
+        format!("{:.prec$}", f, prec = precision)
+    };
+
+    // For values >= 1000 with a suffix, the abs value was used so prepend "-" if negative.
+    if negative && abs_f >= 1e3 {
+        format!("-{}", result)
+    } else {
+        result
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ColumnFormatConfig {
+    named: HashMap<String, NumberFormat>,
+    global: Option<NumberFormat>,
+    /// Decimal places for Fixed/Scientific/Si formats. None uses each format's built-in default.
+    precision: Option<usize>,
+}
+
+impl ColumnFormatConfig {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn insert_named(&mut self, column: String, fmt: NumberFormat) {
+        self.named.insert(column, fmt);
+    }
+
+    pub fn set_global(&mut self, fmt: NumberFormat) {
+        self.global = Some(fmt);
+    }
+
+    pub fn set_precision(&mut self, p: usize) {
+        self.precision = Some(p);
+    }
+
+    pub fn precision(&self) -> Option<usize> {
+        self.precision
+    }
+
+    /// Named config takes priority over global config.
+    pub fn get(&self, column_name: &str) -> Option<&NumberFormat> {
+        if let Some(fmt) = self.named.get(column_name) {
+            return Some(fmt);
+        }
+        self.global.as_ref()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.named.is_empty() && self.global.is_none() && self.precision.is_none()
+    }
+
+    /// Returns true if there are any named (per-column) format configurations.
+    pub fn has_named(&self) -> bool {
+        !self.named.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- from_str ---
+
+    #[test]
+    fn from_str_thousands_aliases() {
+        assert_eq!(NumberFormat::from_str("thousands"), Some(NumberFormat::Thousands));
+        assert_eq!(NumberFormat::from_str("THOUSANDS"), Some(NumberFormat::Thousands));
+    }
+
+    #[test]
+    fn from_str_scientific_aliases() {
+        assert_eq!(NumberFormat::from_str("scientific"), Some(NumberFormat::Scientific));
+        assert_eq!(NumberFormat::from_str("sci"),        Some(NumberFormat::Scientific));
+        assert_eq!(NumberFormat::from_str("SCI"),        Some(NumberFormat::Scientific));
+    }
+
+    #[test]
+    fn from_str_si_aliases() {
+        assert_eq!(NumberFormat::from_str("si"), Some(NumberFormat::Si));
+        assert_eq!(NumberFormat::from_str("SI"), Some(NumberFormat::Si));
+    }
+
+    #[test]
+    fn from_str_fixed_aliases() {
+        assert_eq!(NumberFormat::from_str("fixed"), Some(NumberFormat::Fixed));
+        assert_eq!(NumberFormat::from_str("FIXED"), Some(NumberFormat::Fixed));
+    }
+
+    #[test]
+    fn from_str_unknown() {
+        assert!(NumberFormat::from_str("unknown").is_none());
+        assert!(NumberFormat::from_str("").is_none());
+    }
+
+    // --- Thousands ---
+
+    #[test]
+    fn thousands_positive_integer() {
+        assert_eq!(NumberFormat::Thousands.apply("1234567", None), "1,234,567");
+    }
+
+    #[test]
+    fn thousands_negative_integer() {
+        assert_eq!(NumberFormat::Thousands.apply("-1234", None), "-1,234");
+    }
+
+    #[test]
+    fn thousands_float() {
+        assert_eq!(NumberFormat::Thousands.apply("1234567.89", None), "1,234,567.89");
+    }
+
+    #[test]
+    fn thousands_no_decimal() {
+        assert_eq!(NumberFormat::Thousands.apply("1000", None), "1,000");
+    }
+
+    #[test]
+    fn thousands_small_number() {
+        assert_eq!(NumberFormat::Thousands.apply("999", None), "999");
+    }
+
+    #[test]
+    fn thousands_negative_float() {
+        assert_eq!(NumberFormat::Thousands.apply("-9876543.21", None), "-9,876,543.21");
+    }
+
+    #[test]
+    fn thousands_with_precision() {
+        assert_eq!(NumberFormat::Thousands.apply("1234567.89123", Some(2)), "1,234,567.89");
+        assert_eq!(NumberFormat::Thousands.apply("1234567.89123", Some(0)), "1,234,568");
+    }
+
+    // --- Scientific ---
+
+    #[test]
+    fn scientific_positive() {
+        let result = NumberFormat::Scientific.apply("20263.89", None);
+        // mantissa = 2.026389, exp = 4 → "2.03e4"
+        assert_eq!(result, "2.03e4");
+    }
+
+    #[test]
+    fn scientific_with_precision() {
+        assert_eq!(NumberFormat::Scientific.apply("20263.89", Some(4)), "2.0264e4");
+        assert_eq!(NumberFormat::Scientific.apply("20263.89", Some(0)), "2e4");
+    }
+
+    #[test]
+    fn scientific_negative() {
+        let result = NumberFormat::Scientific.apply("-20263.89", None);
+        assert_eq!(result, "-2.03e4");
+    }
+
+    #[test]
+    fn scientific_small_decimal() {
+        let result = NumberFormat::Scientific.apply("0.00123", None);
+        // exp = floor(log10(0.00123)) = floor(-2.91) = -3
+        // mantissa = 0.00123 / 1e-3 = 1.23
+        assert_eq!(result, "1.23e-3");
+    }
+
+    #[test]
+    fn scientific_zero() {
+        assert_eq!(NumberFormat::Scientific.apply("0", None), "0.00e0");
+    }
+
+    // --- Si ---
+
+    #[test]
+    fn si_kilo() {
+        assert_eq!(NumberFormat::Si.apply("1500", None), "1.50k");
+    }
+
+    #[test]
+    fn si_mega() {
+        assert_eq!(NumberFormat::Si.apply("1234567", None), "1.23M");
+    }
+
+    #[test]
+    fn si_giga() {
+        assert_eq!(NumberFormat::Si.apply("2500000000", None), "2.50B");
+    }
+
+    #[test]
+    fn si_tera() {
+        assert_eq!(NumberFormat::Si.apply("1500000000000", None), "1.50T");
+    }
+
+    #[test]
+    fn si_negative() {
+        assert_eq!(NumberFormat::Si.apply("-1500", None), "-1.50k");
+    }
+
+    #[test]
+    fn si_small() {
+        // Below 1000: no suffix, precision still applies.
+        assert_eq!(NumberFormat::Si.apply("42", None), "42.00");
+        assert_eq!(NumberFormat::Si.apply("42", Some(0)), "42");
+        assert_eq!(NumberFormat::Si.apply("42.123", Some(1)), "42.1");
+    }
+
+    #[test]
+    fn si_with_precision() {
+        assert_eq!(NumberFormat::Si.apply("1500", Some(1)), "1.5k");
+        assert_eq!(NumberFormat::Si.apply("1500", Some(0)), "2k");
+    }
+
+    // --- Fixed ---
+
+    #[test]
+    fn fixed_default_precision() {
+        assert_eq!(NumberFormat::Fixed.apply("23.505744680851063", None), "23.51");
+    }
+
+    #[test]
+    fn fixed_custom_precision() {
+        assert_eq!(NumberFormat::Fixed.apply("23.505744680851063", Some(4)), "23.5057");
+        assert_eq!(NumberFormat::Fixed.apply("23.505744680851063", Some(0)), "24");
+    }
+
+    #[test]
+    fn fixed_negative() {
+        assert_eq!(NumberFormat::Fixed.apply("-23.505744680851063", Some(2)), "-23.51");
+    }
+
+    #[test]
+    fn fixed_non_numeric() {
+        assert_eq!(NumberFormat::Fixed.apply("hello", None), "hello");
+    }
+
+    // --- Non-numeric / edge cases ---
+
+    #[test]
+    fn non_numeric_passthrough() {
+        assert_eq!(NumberFormat::Thousands.apply("hello", None), "hello");
+        assert_eq!(NumberFormat::Scientific.apply("N/A", None), "N/A");
+        assert_eq!(NumberFormat::Si.apply("abc", None), "abc");
+    }
+
+    #[test]
+    fn empty_string_passthrough() {
+        assert_eq!(NumberFormat::Thousands.apply("", None), "");
+        assert_eq!(NumberFormat::Scientific.apply("", None), "");
+        assert_eq!(NumberFormat::Si.apply("", None), "");
+    }
+
+    // --- ColumnFormatConfig ---
+
+    #[test]
+    fn config_named_priority_over_global() {
+        let mut cfg = ColumnFormatConfig::new();
+        cfg.set_global(NumberFormat::Thousands);
+        cfg.insert_named("price".to_string(), NumberFormat::Si);
+
+        assert_eq!(cfg.get("price"), Some(&NumberFormat::Si));
+        assert_eq!(cfg.get("other"), Some(&NumberFormat::Thousands));
+    }
+
+    #[test]
+    fn config_is_empty() {
+        let mut cfg = ColumnFormatConfig::new();
+        assert!(cfg.is_empty());
+        cfg.set_global(NumberFormat::Scientific);
+        assert!(!cfg.is_empty());
+    }
+
+    #[test]
+    fn config_none_when_no_match() {
+        let cfg = ColumnFormatConfig::new();
+        assert!(cfg.get("any_column").is_none());
+    }
+
+    // --- Real-world data scenarios ---
+
+    // NSW electricity price data: values like 23.505744680851063
+    #[test]
+    fn fixed_nsw_electricity_prices() {
+        let values = [
+            ("23.505744680851063", "23.51"),
+            ("19.44625",           "19.45"),
+            ("281.0552083333333",  "281.06"),
+            ("17.108541666666667", "17.11"),
+            ("-5.25",              "-5.25"),
+            ("0.0",                "0.00"),
+        ];
+        for (input, expected) in values {
+            assert_eq!(
+                NumberFormat::Fixed.apply(input, Some(2)),
+                expected,
+                "input: {input}"
+            );
+        }
+    }
+
+    // fixed with precision 0 (integer rounding)
+    // Note: Rust uses round-half-to-even (banker's rounding), so 0.5 → "0", 1.5 → "2"
+    #[test]
+    fn fixed_precision_zero_rounding() {
+        assert_eq!(NumberFormat::Fixed.apply("23.505", Some(0)), "24");
+        assert_eq!(NumberFormat::Fixed.apply("23.499", Some(0)), "23");
+        assert_eq!(NumberFormat::Fixed.apply("-23.505", Some(0)), "-24");
+        assert_eq!(NumberFormat::Fixed.apply("0.4", Some(0)), "0");
+        assert_eq!(NumberFormat::Fixed.apply("0.5", Some(0)), "0"); // banker's rounding: 0.5 → 0
+        assert_eq!(NumberFormat::Fixed.apply("1.5", Some(0)), "2"); // banker's rounding: 1.5 → 2
+    }
+
+    // thousands + precision: financial data
+    #[test]
+    fn thousands_with_precision_financial() {
+        assert_eq!(NumberFormat::Thousands.apply("1234567.8912", Some(2)), "1,234,567.89");
+        assert_eq!(NumberFormat::Thousands.apply("1000000.0",   Some(0)), "1,000,000");
+        assert_eq!(NumberFormat::Thousands.apply("999.999",     Some(1)), "1,000.0");
+        assert_eq!(NumberFormat::Thousands.apply("-9876543.21", Some(2)), "-9,876,543.21");
+    }
+
+    // si + precision: large counts
+    #[test]
+    fn si_with_precision_large_counts() {
+        assert_eq!(NumberFormat::Si.apply("1_500_000", None),    "1_500_000"); // underscores not valid f64
+        assert_eq!(NumberFormat::Si.apply("1500000",   Some(1)), "1.5M");
+        assert_eq!(NumberFormat::Si.apply("1500000",   Some(3)), "1.500M");
+        assert_eq!(NumberFormat::Si.apply("999",       Some(2)), "999.00");    // < 1000, precision applies
+        assert_eq!(NumberFormat::Si.apply("1000",      Some(2)), "1.00k");
+        assert_eq!(NumberFormat::Si.apply("1000000000000", Some(1)), "1.0T");
+    }
+
+    // scientific + precision
+    #[test]
+    fn scientific_with_precision_variety() {
+        assert_eq!(NumberFormat::Scientific.apply("0.00123",   Some(3)), "1.230e-3");
+        assert_eq!(NumberFormat::Scientific.apply("1234567.0", Some(1)), "1.2e6");
+        assert_eq!(NumberFormat::Scientific.apply("1.0",       Some(0)), "1e0");
+        assert_eq!(NumberFormat::Scientific.apply("0",         Some(4)), "0.0000e0");
+    }
+
+    // non-numeric values must pass through unchanged regardless of format
+    #[test]
+    fn passthrough_all_formats() {
+        let non_numeric = ["N/A", "null", "", " ", "2009-01-01", "hello world", "1e", "1.2.3"];
+        for v in non_numeric {
+            assert_eq!(NumberFormat::Fixed.apply(v, Some(2)),      v, "Fixed passthrough: {v:?}");
+            assert_eq!(NumberFormat::Thousands.apply(v, None),     v, "Thousands passthrough: {v:?}");
+            assert_eq!(NumberFormat::Scientific.apply(v, Some(2)), v, "Scientific passthrough: {v:?}");
+            assert_eq!(NumberFormat::Si.apply(v, Some(2)),         v, "Si passthrough: {v:?}");
+        }
+    }
+
+    // precision propagation via ColumnFormatConfig
+    #[test]
+    fn config_precision_propagates() {
+        let mut cfg = ColumnFormatConfig::new();
+        cfg.set_global(NumberFormat::Fixed);
+        cfg.set_precision(3);
+
+        let fmt = cfg.get("any_col").unwrap();
+        assert_eq!(fmt.apply("23.505744680851063", cfg.precision()), "23.506");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod common;
 mod csv;
 mod delimiter;
 pub mod errors;
+pub mod format;
 mod find;
 mod help;
 mod history;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -117,6 +117,30 @@ struct Args {
     /// Disable streaming stdin (load entire input before displaying)
     #[clap(long)]
     pub no_streaming_stdin: bool,
+
+    /// Format numbers in all columns using the specified format.
+    ///
+    /// Supported formats: thousands, scientific, si, fixed
+    ///
+    /// Example: --number-format fixed
+    #[arg(long, value_name = "FORMAT")]
+    pub number_format: Option<String>,
+
+    /// Format numbers in a specific column.
+    ///
+    /// Format: COL=FMT where FMT is one of: thousands, scientific, si, fixed
+    /// Can be specified multiple times for different columns.
+    ///
+    /// Example: --column-format "price=thousands" --column-format "value=fixed"
+    #[arg(long, value_name = "COL=FMT")]
+    pub column_format: Vec<String>,
+
+    /// Number of decimal places for fixed/scientific/si formats (default: 2).
+    /// Applies to all columns. Requires --number-format or --column-format to have any effect.
+    ///
+    /// Example: --number-format fixed --precision 4
+    #[arg(long, value_name = "N")]
+    pub precision: Option<usize>,
 }
 
 #[cfg(feature = "cli")]
@@ -144,8 +168,57 @@ impl Args {
 }
 
 #[cfg(feature = "cli")]
+fn parse_column_format_config(
+    column_format: &[String],
+    number_format: Option<&str>,
+    precision: Option<usize>,
+) -> Option<crate::format::ColumnFormatConfig> {
+    use crate::format::{ColumnFormatConfig, NumberFormat};
+
+    let mut config = ColumnFormatConfig::new();
+
+    // Parse global format
+    if let Some(fmt_str) = number_format {
+        if let Some(fmt) = NumberFormat::from_str(fmt_str) {
+            config.set_global(fmt);
+        } else {
+            eprintln!("Warning: unknown number format '{}', ignoring", fmt_str);
+        }
+    }
+
+    // Parse per-column format "col=fmt"
+    for s in column_format {
+        if let Some((col, fmt_str)) = s.split_once('=') {
+            if let Some(fmt) = NumberFormat::from_str(fmt_str) {
+                config.insert_named(col.to_string(), fmt);
+            } else {
+                eprintln!("Warning: unknown column format '{}' for column '{}', ignoring", fmt_str, col);
+            }
+        } else {
+            eprintln!("Warning: invalid --column-format '{}', expected COL=FMT format, ignoring", s);
+        }
+    }
+
+    // Warn early (before set_precision) so config.is_empty() still reflects format-only state.
+    if precision.is_some() && number_format.is_none() && column_format.is_empty() {
+        eprintln!("Warning: --precision has no effect without --number-format or --column-format");
+    }
+
+    if let Some(p) = precision {
+        config.set_precision(p);
+    }
+
+    if config.is_empty() { None } else { Some(config) }
+}
+
+#[cfg(feature = "cli")]
 impl From<Args> for CsvlensOptions {
     fn from(args: Args) -> Self {
+        let column_format_config = parse_column_format_config(
+            &args.column_format,
+            args.number_format.as_deref(),
+            args.precision,
+        );
         Self {
             filename: args.filename,
             delimiter: args.delimiter,
@@ -164,6 +237,7 @@ impl From<Args> for CsvlensOptions {
             wrap_mode: Args::get_wrap_mode(args.wrap, args.wrap_chars, args.wrap_words),
             auto_reload: args.auto_reload,
             no_streaming_stdin: args.no_streaming_stdin,
+            column_format_config,
         }
     }
 }
@@ -188,6 +262,7 @@ pub struct CsvlensOptions {
     pub wrap_mode: Option<WrapMode>,
     pub auto_reload: bool,
     pub no_streaming_stdin: bool,
+    pub column_format_config: Option<crate::format::ColumnFormatConfig>,
 }
 
 struct AppRunner {
@@ -277,6 +352,7 @@ pub fn run_csvlens_with_options(options: CsvlensOptions) -> CsvlensResult<Option
         options.wrap_mode,
         options.auto_reload,
         options.no_streaming_stdin,
+        options.column_format_config,
     )?;
 
     let mut app_runner = AppRunner::new(app);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -92,12 +92,19 @@ impl<'a> CsvTable<'a> {
     }
 }
 
+fn apply_column_format(value: &str, col_name: &str, cfg: Option<&crate::format::ColumnFormatConfig>) -> Option<String> {
+    let cfg = cfg?;
+    let precision = cfg.precision();
+    cfg.get(col_name).map(|fmt| fmt.apply(value, precision))
+}
+
 impl<'a> CsvTable<'a> {
     fn get_column_widths(
         &self,
         area_width: u16,
         overrides: &ColumnWidthOverrides,
         sorter_state: &SorterState,
+        column_format_config: Option<&crate::format::ColumnFormatConfig>,
     ) -> Vec<u16> {
         let mut column_widths = Vec::new();
 
@@ -122,8 +129,12 @@ impl<'a> CsvTable<'a> {
                     continue;
                 }
                 let v = column_widths.get_mut(i).unwrap();
+                let col_name = self.header.get(i).map(|h| h.name.as_str()).unwrap_or("");
                 value.split('\n').for_each(|x| {
-                    let value_len = x.len() as u16;
+                    let display_len = apply_column_format(x, col_name, column_format_config)
+                        .map(|s| s.len())
+                        .unwrap_or(x.len());
+                    let value_len = display_len as u16;
                     if *v < value_len {
                         *v = value_len;
                     }
@@ -519,6 +530,16 @@ impl<'a> CsvTable<'a> {
                 }
                 active.target.is_match(content)
             };
+
+            // Apply number formatting for data rows (not header rows)
+            let formatted_value: Option<String> = if matches!(row_type, RowType::Record(_)) {
+                let col_name = self.header.get(col_index).map(|h| h.name.as_str()).unwrap_or("");
+                apply_column_format(hname.as_str(), col_name, state.column_format_config.as_deref())
+            } else {
+                None
+            };
+            let display_value: &str = formatted_value.as_deref().unwrap_or(hname.as_str());
+
             match &state.finder_state {
                 // TODO: seems like doing a bit too much of heavy lifting of
                 // checking for matches (finder's work)
@@ -547,7 +568,7 @@ impl<'a> CsvTable<'a> {
                     }
                     let spans = CsvTable::get_highlighted_spans(
                         active,
-                        hname,
+                        display_value,
                         content_style,
                         highlight_style,
                     );
@@ -563,7 +584,7 @@ impl<'a> CsvTable<'a> {
                     );
                 }
                 _ => {
-                    let span = Span::styled((*hname).as_str(), content_style);
+                    let span = Span::styled(display_value, content_style);
                     self.set_spans(
                         buf,
                         &[span],
@@ -625,10 +646,10 @@ impl<'a> CsvTable<'a> {
 
     fn get_highlighted_spans(
         active: &FinderActiveState,
-        hname: &'a str,
+        hname: &str,
         style: Style,
         highlight_style: Style,
-    ) -> Vec<Span<'a>> {
+    ) -> Vec<Span<'static>> {
         let mut spans = Vec::new();
         let mut last = 0;
 
@@ -638,18 +659,18 @@ impl<'a> CsvTable<'a> {
                 continue;
             }
             if last < s {
-                spans.push(Span::styled(&hname[last..s], style));
+                spans.push(Span::styled(hname[last..s].to_owned(), style));
             }
-            spans.push(Span::styled(&hname[s..e], highlight_style));
+            spans.push(Span::styled(hname[s..e].to_owned(), highlight_style));
             last = e;
         }
 
         if last < hname.len() {
-            spans.push(Span::styled(&hname[last..], style));
+            spans.push(Span::styled(hname[last..].to_owned(), style));
         }
 
         if spans.is_empty() {
-            spans.push(Span::styled(hname, style));
+            spans.push(Span::styled(hname.to_owned(), style));
         }
 
         spans
@@ -871,6 +892,7 @@ impl<'a> CsvTable<'a> {
             area.width.saturating_sub(row_num_section_width_with_spaces),
             &state.column_width_overrides,
             &state.sorter_state,
+            state.column_format_config.as_deref(),
         );
         let _tic = std::time::Instant::now();
         let row_heights = self.get_row_heights(
@@ -1327,6 +1349,7 @@ pub struct CsvTableState {
     pub prompt: Option<String>,
     pub last_autoreload_at: Option<Instant>,
     pub debug: String,
+    pub column_format_config: Option<Arc<crate::format::ColumnFormatConfig>>,
 }
 
 impl CsvTableState {
@@ -1368,6 +1391,7 @@ impl CsvTableState {
             prompt,
             last_autoreload_at: None,
             debug: "".into(),
+            column_format_config: None,
         }
     }
 


### PR DESCRIPTION
## Description

  Add number formatting options for display rendering.

  Closes #197

  ## Reasoning

  CSV files often contain raw numeric data that is hard to read at a glance (e.g. `23.505744680851063`, `1234567`, `2500000000`).
  This change adds display-layer formatting so numbers can be rendered in a more human-readable form without affecting the
  underlying data — search, sort, and copy all continue to use original values.

  Four formats are supported:

  | Format | Flag | Example input | Example output |
  |--------|------|---------------|----------------|
  | `thousands` | `--number-format thousands` | `1234567.89` | `1,234,567.89` |
  | `fixed` | `--number-format fixed` | `23.505744680851063` | `23.51` |
  | `si` | `--number-format si` | `2500000000` | `2.50B` |
  | `scientific` | `--number-format scientific` | `0.00123` | `1.23e-3` |

  Non-numeric values (dates, strings, empty cells) are passed through unchanged.

  An optional `--precision N` parameter controls decimal places for `fixed`, `si`, and `scientific` formats (default: 2).

  ## Usage

  ```bash
  # Apply one format to all columns
  csvlens data.csv --number-format fixed --precision 2

  # Per-column format
  csvlens data.csv --column-format "revenue=thousands" --column-format "rate=fixed" --precision 3

  # SI units (useful for large counts)
  csvlens data.csv --number-format si

  # Precision alone has no effect (warns the user)
  csvlens data.csv --precision 2
  # Warning: --precision has no effect without --number-format or --column-format
  ```

  ## Testing

  1. Run `cargo test` — 40 new unit tests in `src/format.rs`, all passing
  2. Open `examples/test_format.csv` with each format and verify display:
     ```bash
     target/release/csvlens examples/test_format.csv --number-format fixed --precision 2
     target/release/csvlens examples/test_format.csv --number-format thousands
     target/release/csvlens examples/test_format.csv --number-format si
     target/release/csvlens examples/test_format.csv --number-format scientific --precision 2
     target/release/csvlens examples/test_format.csv --column-format "value=fixed" --column-format "count=thousands" --precision 3
     ```
  3. Confirm search/filter on formatted columns still uses original values
  4. Confirm non-numeric columns (e.g. `date`) render unchanged
  5. Confirm `--no-headers` + `--column-format` prints a warning

  ## Type of change

  - [ ] Bug fix (A non-breaking change that fixes an issue)
  - [x] New feature (A non-breaking change that adds functionality)
  - [ ] Breaking change (A fix or feature that would cause existing functionality to not work as expected)
  - [ ] Refactor (A code change that neither fixes a bug nor adds a feature)
  - [ ] Performance (A code change that improves performance)
  - [ ] Style (Code style changes)
  - [ ] Docs (Changes to documentation)
  - [ ] Chore (Changes to the build process or other tooling)